### PR TITLE
Also tag APACHE-LICENSE-2.0 as docfile

### DIFF
--- a/templates/opensuse.spec.erb
+++ b/templates/opensuse.spec.erb
@@ -118,6 +118,8 @@ PreReq:         update-alternatives
         license
         license-mit
         mit-license
+        apache-license-2.0
+        license-apache-2.0
         changelog
         news
         release_notes


### PR DESCRIPTION
Some packages (e.g. rubygem-apipie-rails) name it that way