### PR TITLE
add ability to provide alternative main Source

### DIFF
--- a/templates/opensuse.spec.erb
+++ b/templates/opensuse.spec.erb
@@ -73,7 +73,11 @@ BuildRequires:  update-alternatives
 <% unless spec.homepage.nil? || spec.homepage.empty? -%>
 Url:            <%= spec.homepage %>
 <% end -%>
+<% if config[:sourceurl] -%>
+Source:         <%= config[:sourceurl] %>
+<% else -%>
 Source:         http://rubygems.org/gems/%{mod_full_name}.gem
+<% end -%>
 <% if config[:sources]
      config[:sources].each_with_index do |src, i| -%>
 Source<%= i+1 %>:        <%= src %>


### PR DESCRIPTION
this is useful in cases where the gem is not taken from rubygems.org