### PR TITLE
quote version_suffix in gem2rpm.yml.documentation

### DIFF
--- a/gem2rpm.yml.documentation
+++ b/gem2rpm.yml.documentation
@@ -9,7 +9,7 @@
 # ## used by gem2rpm
 # :license: MIT or Ruby
 # ## used by gem2rpm and gem_packages
-# :version_suffix: -x_y
+# :version_suffix: '-x_y'
 # ## used by gem2rpm and gem_packages
 # :disable_docs: true
 # ## used by gem2rpm


### PR DESCRIPTION
 To avoid wrong package names, quote the version_suffix in gem2rpm.yml.documentation.

Tested on Leap 42.2 with ruby2.1-rubygem-gem2rpm-0.10.1-5.3.1.x86_64.

This is what happens, when the suffix is not quoted first, then gets quoted and the spec is recreated:
https://build.opensuse.org/request/show/537785