### PR TITLE
use template "opensuse" on openSUSE Tumbleweed

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -82,6 +82,10 @@ if template_file.nil?
     f.close
     f = nil
   end
+  if template_file.eql? '"opensuse-tumbleweed"'
+    $stderr.puts 'Using template opensuse on Tumbleweed'
+    template_file = 'opensuse'
+  end
 end
 if template_file.nil?
   template = Gem2Rpm::TEMPLATE


### PR DESCRIPTION
use template "opensuse" on openSUSE Tumbleweed, where /etc/os-release contains `ID="opensuse-tumbleweed"`. 

Otherwise you run into the following error:

> Could not open template "opensuse-tumbleweed". Aborting

(tested on Tumbleweed with ruby2.5-rubygem-gem2rpm-0.10.1-13.5.x86_64)

