### PR TITLE
Use the opensuse template on all openSUSE variants

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -82,8 +82,8 @@ if template_file.nil?
     f.close
     f = nil
   end
-  if template_file.eql? '"opensuse-tumbleweed"'
-    $stderr.puts 'Using template opensuse on Tumbleweed'
+  if template_file.match? '^"opensuse'
+    $stderr.puts 'Using template opensuse on openSUSE variant'
     template_file = 'opensuse'
   end
 end


### PR DESCRIPTION
At the moment you have to manually specify the template file name on Leap, as
gem2rpm tries to use the opensuse-leap template on Leap, which does not
exist. Therefore we fallback to the opensuse template instead.