### PR TITLE
Minor improvements for the templates

### DIFF
--- a/templates/gem_packages.spec.erb
+++ b/templates/gem_packages.spec.erb
@@ -191,6 +191,7 @@ Usually in RDoc and RI formats.
      }
      %w(changes
         copying
+        contributing
         history
         legal
         licence

--- a/templates/opensuse.spec.erb
+++ b/templates/opensuse.spec.erb
@@ -184,6 +184,7 @@ find -type f -print0 | xargs -0 touch -r %{S:0}
 # /MANUAL
 
 <% end -%>
+find %{buildroot} -name .gitignore -print -delete
 
 <% if config[:testsuite_command] -%>
 # MANUAL

--- a/templates/opensuse.spec.erb
+++ b/templates/opensuse.spec.erb
@@ -116,6 +116,7 @@ License:        <%= config[:license] or (spec.licenses and spec.licenses.join(" 
      }
      %w(changes
         copying
+        contributing
         history
         legal
         licence


### PR DESCRIPTION
While working on the amazing_print rubygem in OBS I stumbled over these. It seems better to handle them in gem2rpm for all rubygems instead of changing a lot of gem2rpm.yml.