### PR TITLE
Handle "contributing" as a candidate for docdirfiles

### DIFF
--- a/templates/gem_packages.spec.erb
+++ b/templates/gem_packages.spec.erb
@@ -191,6 +191,7 @@ Usually in RDoc and RI formats.
      }
      %w(changes
         copying
+        contributing
         history
         legal
         licence

--- a/templates/opensuse.spec.erb
+++ b/templates/opensuse.spec.erb
@@ -116,6 +116,7 @@ License:        <%= config[:license] or (spec.licenses and spec.licenses.join(" 
      }
      %w(changes
         copying
+        contributing
         history
         legal
         licence


### PR DESCRIPTION
While working on the amazing_print rubygem in OBS I stumbled over this one. It seems better to handle this in gem2rpm for all rubygems instead of changing a lot of gem2rpm.yml.